### PR TITLE
feat: Add NotMatchValidator to check for non-equal values

### DIFF
--- a/lib/pro_validator.dart
+++ b/lib/pro_validator.dart
@@ -1,5 +1,5 @@
 /// pro_validator is a dart package that provides a set of validators
-library pro_validator;
+library;
 
 abstract class Validator<T> {
   const Validator({required this.error});
@@ -258,6 +258,17 @@ class MatchValidator {
   final String error;
 
   String? call(String? v1, String? v2) => v1 == v2 ? null : error;
+}
+
+/// A special match validator to check if the v1 not equals v2 value.
+class NotMatchValidator {
+  NotMatchValidator({
+    required this.error,
+  });
+
+  final String error;
+
+  String? call(String? v1, String? v2) => v1 != v2 ? null : error;
 }
 
 /// Group together and validate the basic validators.


### PR DESCRIPTION
Added NotMatchValidator that checks whether a != b and returns error if if it is not.


P.s. This method is not necessary. Same logic could be achieved using flag negate comparison

class MatchValidator {
  MatchValidator({
    required this.error,
    this.negateComparison = false,
  });

  final String error;
  final bool negateComparison;

  String? call(String? v1, String? v2) {
    if (negateComparison) {
      return v1 != v2 ? null : error;
    }

    return v1 == v2 ? null : error;
  }
}